### PR TITLE
init This commit introduces a new web-based rich text editor for viewing a…

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CLML Rich Text Editor</title>
+    <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>CLML Rich Text Editor</h1>
+    <div class="tabs">
+        <button id="rich-text-tab" class="tab-button active">Rich Text Editor</button>
+        <button id="xml-tab" class="tab-button">Raw XML</button>
+    </div>
+    <div id="editor-container" class="editor-view">
+        <div id="quill-editor"></div>
+    </div>
+    <div id="xml-container" class="editor-view" style="display: none;">
+        <textarea id="xml-editor"></textarea>
+    </div>
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,183 @@
+document.addEventListener('DOMContentLoaded', () => {
+    let originalXmlDoc;
+    let isUpdating = false;
+
+    const quill = new Quill('#quill-editor', {
+        theme: 'snow',
+        modules: {
+            toolbar: [
+                [{ 'header': [1, 2, 3, false] }],
+                ['bold', 'italic', 'underline'],
+                [{ 'list': 'ordered'}, { 'list': 'bullet' }],
+                ['link'],
+                ['clean']
+            ]
+        }
+    });
+
+    const xmlEditor = document.getElementById('xml-editor');
+    const richTextTab = document.getElementById('rich-text-tab');
+    const xmlTab = document.getElementById('xml-tab');
+    const editorContainer = document.getElementById('editor-container');
+    const xmlContainer = document.getElementById('xml-container');
+
+    // Tab switching logic
+    richTextTab.addEventListener('click', () => {
+        editorContainer.style.display = 'block';
+        xmlContainer.style.display = 'none';
+        richTextTab.classList.add('active');
+        xmlTab.classList.remove('active');
+    });
+
+    xmlTab.addEventListener('click', () => {
+        editorContainer.style.display = 'none';
+        xmlContainer.style.display = 'block';
+        xmlTab.classList.add('active');
+        richTextTab.classList.remove('active');
+    });
+
+    // Fetch and load initial data
+    fetch('clml.xml')
+        .then(response => response.text())
+        .then(str => {
+            const parser = new DOMParser();
+            originalXmlDoc = parser.parseFromString(str, "application/xml");
+
+            updateQuillFromXml(originalXmlDoc);
+            updateXmlEditor(originalXmlDoc);
+        })
+        .catch(err => {
+            console.error('Error fetching or parsing clml.xml:', err);
+            quill.root.innerHTML = `<p>Error: ${err.message}</p>`;
+        });
+
+    // Two-way binding listeners
+    quill.on('text-change', (delta, oldDelta, source) => {
+        if (source === 'user' && !isUpdating) {
+            isUpdating = true;
+            const newXmlDoc = htmlToClml(quill.root.innerHTML, originalXmlDoc);
+            updateXmlEditor(newXmlDoc);
+            originalXmlDoc = newXmlDoc; // Update the reference
+            isUpdating = false;
+        }
+    });
+
+    xmlEditor.addEventListener('input', () => {
+        if (!isUpdating) {
+            isUpdating = true;
+            const parser = new DOMParser();
+            const newXmlDoc = parser.parseFromString(xmlEditor.value, "application/xml");
+
+            const parseError = newXmlDoc.querySelector('parsererror');
+            if (parseError) {
+                console.error('XML parsing error:', parseError);
+            } else {
+                updateQuillFromXml(newXmlDoc);
+                originalXmlDoc = newXmlDoc; // Update the reference
+            }
+            isUpdating = false;
+        }
+    });
+
+    function updateQuillFromXml(xmlDoc) {
+        const primaryNode = xmlDoc.getElementsByTagName('Primary')[0];
+        if (primaryNode) {
+            const html = clmlNodeToHtml(primaryNode);
+            quill.root.innerHTML = html;
+        } else {
+            quill.root.innerHTML = "<p>Error: Could not find &lt;Primary&gt; element.</p>";
+        }
+    }
+
+    function updateXmlEditor(xmlDoc) {
+        const serializer = new XMLSerializer();
+        const xmlString = serializer.serializeToString(xmlDoc);
+        xmlEditor.value = formatXml(xmlString);
+    }
+});
+
+function clmlNodeToHtml(node) {
+    if (node.nodeType === Node.TEXT_NODE) {
+        return node.textContent;
+    }
+    if (node.nodeType !== Node.ELEMENT_NODE) {
+        return '';
+    }
+
+    let childrenHtml = Array.from(node.childNodes).map(clmlNodeToHtml).join('');
+
+    // Basic mapping, can be expanded
+    switch (node.nodeName) {
+        case 'Title': return `<h2>${childrenHtml}</h2>`;
+        case 'LongTitle': return `<h3>${childrenHtml}</h3>`;
+        case 'Para':
+        case 'Text': return `<p>${childrenHtml}</p>`;
+        case 'Emphasis': return `<em>${childrenHtml}</em>`;
+        case 'SmallCaps': return `<span style="font-variant: small-caps;">${childrenHtml}</span>`;
+        case 'Term': return `<strong>${childrenHtml}</strong>`;
+        case 'UnorderedList': return `<ul>${childrenHtml}</ul>`;
+        case 'ListItem': return `<li>${childrenHtml}</li>`;
+        default: return `<div>${childrenHtml}</div>`; // Default to a div for structure
+    }
+}
+
+function htmlToClml(htmlString, baseXmlDoc) {
+    const newXmlDoc = baseXmlDoc.cloneNode(true);
+    const primaryNode = newXmlDoc.getElementsByTagName('Primary')[0];
+
+    if (!primaryNode) return newXmlDoc;
+
+    while (primaryNode.firstChild) {
+        primaryNode.removeChild(primaryNode.firstChild);
+    }
+
+    const tempDiv = document.createElement('div');
+    tempDiv.innerHTML = htmlString;
+
+    function traverse(htmlNode, clmlParent) {
+        htmlNode.childNodes.forEach(child => {
+            let newClmlNode;
+
+            if (child.nodeType === Node.TEXT_NODE && child.textContent.trim() !== '') {
+                const textWrapper = newXmlDoc.createElement('Text');
+                textWrapper.appendChild(newXmlDoc.createTextNode(child.textContent));
+                clmlParent.appendChild(textWrapper);
+                return;
+            }
+
+            if (child.nodeType !== Node.ELEMENT_NODE) return;
+
+            switch (child.nodeName) {
+                case 'H2': newClmlNode = newXmlDoc.createElement('Title'); break;
+                case 'H3': newClmlNode = newXmlDoc.createElement('LongTitle'); break;
+                case 'P': newClmlNode = newXmlDoc.createElement('Para'); break;
+                case 'EM': newClmlNode = newXmlDoc.createElement('Emphasis'); break;
+                case 'STRONG': newClmlNode = newXmlDoc.createElement('Term'); break;
+                case 'UL': newClmlNode = newXmlDoc.createElement('UnorderedList'); break;
+                case 'LI': newClmlNode = newXmlDoc.createElement('ListItem'); break;
+                default: newClmlNode = newXmlDoc.createElement('P1'); break; // Default to a structural tag
+            }
+
+            if (newClmlNode) {
+                clmlParent.appendChild(newClmlNode);
+                traverse(child, newClmlNode);
+            } else {
+                traverse(child, clmlParent);
+            }
+        });
+    }
+
+    traverse(tempDiv, primaryNode);
+    return newXmlDoc;
+}
+
+function formatXml(xml) {
+    let formatted = '', indent= '';
+    const tab = '  ';
+    xml.split(/>\s*</).forEach(node => {
+        if (node.match( /^\/\w/ )) indent = indent.substring(tab.length);
+        formatted += indent + '<' + node + '>\r\n';
+        if (node.match( /^<?\w[^>]*[^\/]$/ )) indent += tab;
+    });
+    return formatted.substring(1, formatted.length - 3);
+}

--- a/style.css
+++ b/style.css
@@ -1,0 +1,47 @@
+body {
+    font-family: sans-serif;
+    margin: 20px;
+    background-color: #f4f4f4;
+}
+
+h1 {
+    text-align: center;
+    color: #333;
+}
+
+.tabs {
+    margin-bottom: 10px;
+}
+
+.tab-button {
+    padding: 10px 20px;
+    cursor: pointer;
+    border: 1px solid #ccc;
+    background-color: #f0f0f0;
+    border-bottom: none;
+    border-radius: 5px 5px 0 0;
+}
+
+.tab-button.active {
+    background-color: #fff;
+    border-bottom: 1px solid #fff;
+}
+
+.editor-view {
+    border: 1px solid #ccc;
+    padding: 10px;
+    background-color: #fff;
+    border-radius: 0 5px 5px 5px;
+}
+
+#quill-editor {
+    height: 600px;
+}
+
+#xml-editor {
+    width: 100%;
+    height: 600px;
+    border: none;
+    resize: none;
+    font-family: monospace;
+}


### PR DESCRIPTION
…nd editing CLML XML files.

The editor provides a dual-view interface with two synchronized tabs:
- A "Rich Text Editor" tab using the Quill.js library for a user-friendly editing experience.
- A "Raw XML" tab with a textarea for viewing and editing the source XML directly.

The implementation includes:
- An HTML file (`index.html`) for the structure of the editor.
- A CSS file (`style.css`) for styling the interface.
- A JavaScript file (`main.js`) that contains the core logic for:
  - Fetching and parsing the `clml.xml` file.
  - Converting the CLML XML to HTML for the rich text view.
  - Converting the edited HTML back to CLML XML.
  - Implementing two-way data binding to keep both views in sync.
  - A simple XML formatter for the raw XML view.